### PR TITLE
before_filter -> before_action

### DIFF
--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -12,8 +12,8 @@ class DiaryEntriesController < ApplicationController
   helper :custom_fields
   include CustomFieldsHelper
 
-  before_filter :find_project_and_issue, :authorize_creation, :only => :create
-  before_filter :find_time_entry, :only => [:destroy, :edit, :update]
+  before_action :find_project_and_issue, :authorize_creation, :only => :create
+  before_action :find_time_entry, :only => [:destroy, :edit, :update]
 
   def index
     # For the listing


### PR DESCRIPTION
"before_filter" no longer works in Rails > 5.1.